### PR TITLE
fix(setup): Allow custom opts to contain subset of keys

### DIFF
--- a/lua/hbac/setup.lua
+++ b/lua/hbac/setup.lua
@@ -8,10 +8,10 @@ local id = vim.api.nvim_create_augroup("hbac", {
 })
 
 M.setup = function(opts)
-	opts = opts or {
+	opts = vim.tbl_extend("force", {
 		autoclose = true,
-		threshold = 10
-	}
+		threshold = 10,
+	}, opts)
 
 	vim.api.nvim_create_autocmd({ "BufRead" }, {
 		group = id,

--- a/lua/hbac/setup.lua
+++ b/lua/hbac/setup.lua
@@ -22,6 +22,9 @@ M.setup = function(opts)
 				once = true,
 				callback = function()
 					local bufnr = vim.api.nvim_get_current_buf()
+					if state.is_pinned(bufnr) then
+						return
+					end
 					state.toggle_pin(bufnr)
 				end
 			})


### PR DESCRIPTION
## Summary
- Allows custom options to contain only a subset of the entire options set, overriding default values.
- Avoid unpinning already pinned buffers on `InsertEnter` or `BufModifiedSet`
