### PR TITLE
feat: pass buffer options to hbac.telescope

### DIFF
--- a/lua/hbac/telescope/attach_mappings.lua
+++ b/lua/hbac/telescope/attach_mappings.lua
@@ -3,11 +3,12 @@ local action_state = require("telescope.actions.state")
 local config = require("hbac.config")
 local state = require("hbac.state")
 local actions = require("hbac.command.actions")
-local make_finder = require("hbac.telescope.make_finder").make_finder
+local make_finder = require("hbac.telescope.make_finder")
 
 local M = {}
 
 local function execute_telescope_action(prompt_bufnr, action)
+	local finder, finder_opts = make_finder.make_finder, make_finder.finder_opts
 	local picker = action_state.get_current_picker(prompt_bufnr)
 	local multi_selection = picker:get_multi_selection()
 
@@ -24,7 +25,7 @@ local function execute_telescope_action(prompt_bufnr, action)
 	picker:register_completion_callback(function()
 		picker:set_selection(row)
 	end)
-	picker:refresh(make_finder(), { reset_prompt = false })
+	picker:refresh(finder(finder_opts), { reset_prompt = false })
 end
 
 local function hbac_toggle_selections(prompt_bufnr)

--- a/lua/hbac/telescope/init.lua
+++ b/lua/hbac/telescope/init.lua
@@ -18,15 +18,16 @@ local M = {}
 
 M.pin_picker = function(opts)
 	local attach_mappings = require("hbac.telescope.attach_mappings")
-	local make_finder = require("hbac.telescope.make_finder").make_finder
+	local make_finder = require("hbac.telescope.make_finder")
 	opts = opts or {}
 	pickers
 		.new(opts, {
 			prompt_title = "Hbac Pin States",
-			finder = make_finder(),
+			finder = make_finder.make_finder(opts),
 			sorter = telescope_conf.generic_sorter(opts),
 			attach_mappings = attach_mappings.attach_mappings,
 			previewer = telescope_conf.file_previewer(opts),
+			default_selection_index = make_finder.default_selection_idx,
 		})
 		:find()
 end

--- a/lua/hbac/telescope/results_opts.lua
+++ b/lua/hbac/telescope/results_opts.lua
@@ -1,0 +1,58 @@
+-- NOTE: These are copied/modified from telescope.builtin.internal.buffers
+local M = {}
+
+local most_recent_bufs = function(bufnrs)
+	local mru_bufs = {}
+	for _, buf in ipairs(bufnrs) do
+		table.insert(mru_bufs, buf)
+	end
+	table.sort(mru_bufs, function(a, b)
+		return vim.fn.getbufinfo(a)[1].lastused > vim.fn.getbufinfo(b)[1].lastused
+	end)
+	return mru_bufs
+end
+
+M.filter_bufnrs_by_opts = function(opts, bufnrs)
+	local mru_bufs = most_recent_bufs(bufnrs)
+	bufnrs = vim.tbl_filter(function(b)
+		local function buf_in_cwd(cwd)
+			return string.find(vim.api.nvim_buf_get_name(b), cwd, 1, true)
+		end
+		if
+			(opts.show_all_buffers == false and not vim.api.nvim_buf_is_loaded(b))
+			or (opts.ignore_current_buffer and b == mru_bufs[1])
+			or (opts.cwd_only and not buf_in_cwd(vim.loop.cwd()))
+			or (not opts.cwd_only and opts.cwd and not buf_in_cwd(opts.cwd))
+		then
+			return false
+		end
+		return true
+	end, bufnrs)
+
+	if not next(bufnrs) then
+		return {}
+	end
+	if opts.sort_mru then
+		bufnrs = most_recent_bufs(bufnrs)
+	end
+
+	local default_selection_idx = 1
+	if opts.sort_lastused then
+		local active, alternate = mru_bufs[1], mru_bufs[2]
+		local idx = 1
+		for i, bufnr in ipairs(bufnrs) do
+			if not opts.ignore_current_buffer and bufnr == active then
+				default_selection_idx = 2
+			end
+			if bufnr == active or bufnr == alternate then
+				idx = (opts.ignore_current_buffer or bufnrs[1] ~= active) and 1 or 2
+				table.remove(bufnrs, i)
+				table.insert(bufnrs, idx, bufnr)
+			end
+		end
+	end
+
+	return bufnrs, default_selection_idx
+end
+
+return M


### PR DESCRIPTION
This commit adds a new module, `hbac.telescope.results_opts`, which filters the results of the entry picker to only show buffers that match the options passed to the picker. This commit supports the options listed in `:h telescope.builtin.buffers()` (except for `bufnr_width`, since bufnr is not displayed in the hbac picker)

Example usage:

```lua
vim.keymap.set("n", ",ht", function()
    local default_opts = {
        show_all_buffers = true,
        sort_mru = true,
        sort_lastused = true,
        ignore_current_buffer = true,
        cwd_only = false,
        cwd = nil,
    }
    require("hbac").telescope(default_opts)
end, { desc = "Hbac: pin picker", noremap = true })
```

addresses #9 #12