### PR TITLE
feat(telescope)!: create telescope extension for pin picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,13 @@ The main feature of this plugin, however, is the automatic closing of buffers. I
 
 with [packer.nvim](https://github.com/wbthomason/packer.nvim)
 ```lua
-use {
-  'axkirillov/hbac.nvim',
-  requires = {
-  -- these are optional, add them, if you want the telescope module
-    'nvim-telescope/telescope.nvim',
-    'nvim-lua/plenary.nvim',
-    'nvim-tree/nvim-web-devicons'
-    }
-}
+use { 'axkirillov/hbac.nvim' }
 ```
 with [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
 {
   'axkirillov/hbac.nvim',
-  dependencies = {
-  -- these are optional, add them, if you want the telescope module
-    'nvim-telescope/telescope.nvim',
-    'nvim-lua/plenary.nvim',
-    'nvim-tree/nvim-web-devicons'
-  },
-  config = function ()
-    require("hbac").setup()
-  end
+  config = true,
 }
 ```
 
@@ -74,12 +58,26 @@ hbac.close_unpinned()
 hbac.pin_all()
 hbac.unpin_all()
 hbac.toggle_autoclose()
-hbac.telescope()
 ```
 
-## Telescope integration
+## Telescope extension
 
-The plugin provides a [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) integration to view and manage the pin states of buffers. This requires telescope and its dependency [plenary.nvim](https://github.com/nvim-lua/plenary.nvim). [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons) is also recommended.
+The plugin provides a [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) extension to view and manage the pin states of buffers. This requires telescope and its dependency [plenary.nvim](https://github.com/nvim-lua/plenary.nvim). [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons) is also recommended.
+
+### Usage
+To use the telescope picker, load the hbac telescope extension in your config file.
+```lua
+require('telescope').load_extension('hbac')
+```
+
+After loading the extension, you can execute the picker like so:
+```
+:Telescope hbac buffers
+```
+or if you prefer lua:
+```lua
+require('telescope').extensions.hbac.buffers()
+```
 
 The picker provides the following actions:
 
@@ -145,7 +143,7 @@ telescope = {
 You can also pass options to the picker directly when calling its function. These options will deep-extend your setup table.
 
 ```lua
-require("hbac").telescope({
+require("telescope").extensions.hbac.buffers({
   file_ignore_patterns = { ".json" },
   layout_strategy = "horizontal",
   -- etc.
@@ -170,3 +168,4 @@ lualine_c = {
     }
   }
 ```
+

--- a/lua/hbac/command/subcommands.lua
+++ b/lua/hbac/command/subcommands.lua
@@ -28,14 +28,8 @@ M.toggle_autoclose = function()
 	vim.notify("Autoclose " .. autoclose_state, vim.log.levels.INFO, notify_opts)
 end
 
-M.telescope = function(opts)
-	local hbac_telescope = require("hbac.telescope")
-	if not hbac_telescope then
-		return
-	end
-	local telescope_opts = require("hbac.config").values.telescope
-	opts = vim.tbl_deep_extend("force", telescope_opts, opts or {})
-	hbac_telescope.pin_picker(opts)
+M.telescope = function()
+	vim.notify('This command has been removed. Check the docs for a migration guide.', vim.log.levels.WARN, notify_opts)
 end
 
 return M

--- a/lua/hbac/config.lua
+++ b/lua/hbac/config.lua
@@ -1,14 +1,4 @@
-local actions = require("hbac.telescope.actions")
-
 local M = {}
-
-local action_mappings = {
-	["<M-c>"] = actions.close_unpinned,
-	["<M-x>"] = actions.delete_buffer,
-	["<M-a>"] = actions.pin_all,
-	["<M-u>"] = actions.unpin_all,
-	["<M-y>"] = actions.toggle_pin,
-}
 
 local defaults = {
 	autoclose = true,
@@ -19,10 +9,8 @@ local defaults = {
 		sort_mru = true,
 		sort_lastused = true,
 		selection_strategy = "row",
-		mappings = {
-			n = action_mappings,
-			i = action_mappings,
-		},
+		use_default_mappings = true,
+		mappings = nil,
 		pin_icons = {
 			pinned = { "󰐃 ", hl = "DiagnosticOk" },
 			unpinned = { "󰤱 ", hl = "DiagnosticError" },

--- a/lua/hbac/telescope/init.lua
+++ b/lua/hbac/telescope/init.lua
@@ -1,26 +1,20 @@
-local missing = ""
-for _, dependency in ipairs({ "plenary", "telescope" }) do
-	if not pcall(require, dependency) then
-		missing = missing .. "\n- " .. dependency .. ".nvim"
-	end
-end
-
-if missing ~= "" then
-	local msg = "Missing dependencies:" .. missing
-	vim.notify(msg, vim.log.levels.ERROR, { title = "Hbac" })
-	return false
-end
-
+local actions = require("hbac.telescope.actions")
 local pickers = require("telescope.pickers")
 local telescope_conf = require("telescope.config").values
+
+local default_mappings = {
+	["<M-c>"] = actions.close_unpinned,
+	["<M-x>"] = actions.delete_buffer,
+	["<M-a>"] = actions.pin_all,
+	["<M-u>"] = actions.unpin_all,
+	["<M-y>"] = actions.toggle_pin,
+}
 
 local M = {}
 
 local attach_mappings = function(opts)
 	return function(_, map)
-		local telescope_mappings = require("hbac.config").values.telescope.mappings
-		telescope_mappings = vim.tbl_deep_extend("force", telescope_mappings, opts.mappings or {})
-		for mode, hbac_telescope_mappings in pairs(telescope_mappings) do
+		for mode, hbac_telescope_mappings in pairs(opts.mappings) do
 			for key, action in pairs(hbac_telescope_mappings) do
 				map(mode, key, action)
 			end
@@ -29,9 +23,17 @@ local attach_mappings = function(opts)
 	end
 end
 
+local parse_opts = function(opts)
+	local telescope_opts = require("hbac.config").values.telescope
+	opts.mappings = telescope_opts.use_default_mappings
+		and vim.tbl_deep_extend('force', { i = default_mappings, n = default_mappings }, telescope_opts.mappings or {})
+		or (telescope_opts.mappings or {})
+	return vim.tbl_deep_extend("force", telescope_opts, opts or {})
+end
+
 M.pin_picker = function(opts)
 	local make_finder = require("hbac.telescope.make_finder")
-	opts = opts or {}
+	opts = parse_opts(opts or {})
 	pickers.new(opts, {
 		prompt_title = "Hbac Pin States",
 		finder = make_finder.make_finder(opts),

--- a/lua/telescope/_extensions/hbac.lua
+++ b/lua/telescope/_extensions/hbac.lua
@@ -1,0 +1,7 @@
+local telescope = require('telescope')
+
+return telescope.register_extension({
+	exports = {
+		buffers = require('hbac.telescope').pin_picker,
+	}
+})


### PR DESCRIPTION
Hey there! This PR creates a telescope extension that replaces the telescope command of this plugin. Technically this is a BREAKING CHANGE although things still work mostly the same.

Changes:
- remove the `Hbac telescope` command
- add telescope setting `use_default_mappings`
- add telescope extension
- update docs accordingly

The big advantage of using a telescope extension is that hbac doesn't need to load telescope as a dependency. Instead it's the other way around: if you use the telescope picker, telescope will have to load hbac as a dependency (although chances are it will already be loaded anyway).

I personally lazyload telescope, so as long as I don't use it, it won't be loaded but previously hbac always loaded telscope no matter what, which rendered my lazyloading setup kind of useless. This fixes that problem.

I also added a new setting, which lets you avoid the default telescope mappings if you don't want them.

I updated the docs accordingly, but feel free to notify me if I missed anything. 
All previous features (passing options to the picker directly, etc.) should still work the same.