### PR TITLE
fix(telescope): pass opts from direct func call

### DIFF
--- a/lua/hbac/config.lua
+++ b/lua/hbac/config.lua
@@ -10,7 +10,7 @@ local defaults = {
 		sort_lastused = true,
 		selection_strategy = "row",
 		use_default_mappings = true,
-		mappings = nil,
+		mappings = {},
 		pin_icons = {
 			pinned = { "󰐃 ", hl = "DiagnosticOk" },
 			unpinned = { "󰤱 ", hl = "DiagnosticError" },

--- a/lua/hbac/telescope/init.lua
+++ b/lua/hbac/telescope/init.lua
@@ -25,10 +25,11 @@ end
 
 local parse_opts = function(opts)
 	local telescope_opts = require("hbac.config").values.telescope
-	opts.mappings = telescope_opts.use_default_mappings
-		and vim.tbl_deep_extend('force', { i = default_mappings, n = default_mappings }, telescope_opts.mappings or {})
-		or (telescope_opts.mappings or {})
-	return vim.tbl_deep_extend("force", telescope_opts, opts or {})
+	if telescope_opts.use_default_mappings then
+		default_mappings = { i = default_mappings, n = default_mappings }
+		telescope_opts.mappings = vim.tbl_deep_extend("force", default_mappings, telescope_opts.mappings)
+	end
+	return vim.tbl_deep_extend("force", telescope_opts, opts)
 end
 
 M.pin_picker = function(opts)


### PR DESCRIPTION
Let telescope opts priority order be:
1. opts arg from a function call
2. `telescope` table from the user defined config
3. default hbac.config.values.telescope opts

Say you want call the picker with a function call instead of using `:Telescope hbac` buffers e.g. `require('telescope').extensions.hbac.buffers(opts)` or `require('hbac.telescope').pin_picker(opts)`. 
The current `parse_opts` function overwrites opts.mappings with the merged default_mappings + telescope_opts.mappings tables.

```lua
opts.mappings = telescope_opts.use_default_mappings
  and vim.tbl_deep_extend('force', { i = default_mappings, n = default_mappings }, telescope_opts.mappings or {})
  or (telescope_opts.mappings or {})
```

The function prioritizes other options from a function call (e.g. if you set `sort_lastused = false`, it will override the config default), but it doesn't account for any potential value of `opts.mappings` before the assignment above.

In 610a604 the priority order was as described above and currently in the README, but I forgot to check for that when we switched to the Telescope extension. This PR should restore that:

```lua
local parse_opts = function(opts)
  -- by this point, user's config opts > default opts
  local telescope_opts = require("hbac.config").values.telescope
  if telescope_opts.use_default_mappings then
    default_mappings = { i = default_mappings, n = default_mappings } 
    -- user defined mappings > default mappings
    telescope_opts.mappings = vim.tbl_deep_extend("force", default_mappings, telescope_opts.mappings)
  end
  -- opts/mappings from function args (if any) > config opts/mappings
  return vim.tbl_deep_extend("force", telescope_opts, opts)
end
```

I also set the default telescope.mappings value to `{}` instead of nil to spare some 'check for nil' disjunctions (lua_ls and luacheck aren't complaining about that, do I have a bad config?).

<details>
<summary>sample lazy.nvim config</summary>

```lua
return {
  -- "axkirillov/hbac.nvim",
  "al-ce/hbac.nvim",
  branch = "telescope/config-override",
  opts = {
    telescope = {
      mappings = {
        i = { ["<M-z>"] = function() print("Hello hbac") end, },
      }
    }
  },
  keys = {
    {
      ",ht",
      function()
        require('telescope').extensions.hbac.buffers({
          sort_lastused = false,  -- should override default
          mappings = {
            i = {
              ["<M-z>"] = function() print("Goodbye hbac") end,  -- should override above mappings
              ["<M-j>"] = function() print("Where am I?") end,
            },
          },
        })
      end,
      desc = "Hbac: Telescope",
    },
  }
}
```

</details>