### PR TITLE
feat(state): keep global state of pinned buffers for session persistence

### DIFF
--- a/lua/hbac/command/actions.lua
+++ b/lua/hbac/command/actions.lua
@@ -19,20 +19,28 @@ M.toggle_pin = function(bufnr)
 	return bufnr, pinned_state
 end
 
-M.set_all = function(pin_value)
+local set_all = function(pin_value)
 	local utils = require("hbac.utils")
 	local buflist = utils.get_listed_buffers()
-	for _, bufnr in ipairs(buflist) do
-		state.pinned_buffers[bufnr] = pin_value
+	local pins = utils.int_explode(vim.g.hbac_buffers or "")
+	if not pin_value then
+		vim.g.hbac_buffers = ""
+		return
 	end
+	for _, bufnr in ipairs(buflist) do
+		if not vim.tbl_contains(pins, bufnr) then
+			table.insert(pins, bufnr)
+		end
+	end
+	vim.g.hbac_buffers = table.concat(pins, ",")
 end
 
 M.pin_all = function()
-	M.set_all(true)
+	set_all(true)
 end
 
 M.unpin_all = function()
-	M.set_all(false)
+	set_all(false)
 end
 
 M.toggle_autoclose = function()

--- a/lua/hbac/state.lua
+++ b/lua/hbac/state.lua
@@ -1,15 +1,24 @@
 local M = {
-	pinned_buffers = {},
 	autoclose_enabled = false,
 }
 
 M.toggle_pin = function(bufnr)
-	M.pinned_buffers[bufnr] = not M.pinned_buffers[bufnr]
-	return M.pinned_buffers[bufnr]
+	local utils = require("hbac.utils")
+	local pins = utils.int_explode(vim.g.hbac_buffers or "")
+	if vim.tbl_contains(pins, bufnr) then
+		local filtered_pins = vim.tbl_filter(function(pin) return pin ~= bufnr end, pins)
+		vim.g.hbac_buffers = table.concat(filtered_pins, ",")
+		return false
+	end
+	table.insert(pins, bufnr)
+	vim.g.hbac_buffers = table.concat(pins, ",")
+	return true
 end
 
 M.is_pinned = function(bufnr)
-	return M.pinned_buffers[bufnr] == true
+	local utils = require("hbac.utils")
+	local pins = utils.int_explode(vim.g.hbac_buffers or "")
+	return vim.tbl_contains(pins, bufnr)
 end
 
 return M

--- a/lua/hbac/utils.lua
+++ b/lua/hbac/utils.lua
@@ -21,4 +21,15 @@ M.buf_autoclosable = function(bufnr)
 	return true
 end
 
+M.int_explode = function(str)
+	if string.len(str) == 0 then
+		return {}
+	end
+	local t = {}
+	for entry in string.gmatch(str, "[^,]+") do
+		table.insert(t, tonumber(entry))
+	end
+	return t
+end
+
 return M


### PR DESCRIPTION
Hey again!

This should fix #15.

I also made `set_all` a local function, as it seemed kind of useless to export it (I can remove that change tho, if you don't like it). 
I won't lie, I don't use any session plugins, so I am not exactly sure on how they operate. If this has any issues, feel free to point them out.