### PR TITLE
fix(telescope): prevent recursive `i` and `n` mappings

### DIFF
--- a/lua/hbac/telescope/init.lua
+++ b/lua/hbac/telescope/init.lua
@@ -26,8 +26,8 @@ end
 local parse_opts = function(opts)
 	local telescope_opts = require("hbac.config").values.telescope
 	if telescope_opts.use_default_mappings then
-		default_mappings = { i = default_mappings, n = default_mappings }
-		telescope_opts.mappings = vim.tbl_deep_extend("force", default_mappings, telescope_opts.mappings)
+		telescope_opts.mappings =
+			vim.tbl_deep_extend("force", { i = default_mappings, n = default_mappings }, telescope_opts.mappings)
 	end
 	return vim.tbl_deep_extend("force", telescope_opts, opts)
 end


### PR DESCRIPTION
Fixes issue where subsequent telescope calls would set mappings to something like:
```
{
  i = { i = { "<M-x>" = actions.delete_buffer }, n = { } }
}  -- etc.
```

Fixes #24 