### PR TITLE
feat(state): save global state for compatibility with session managers

### DIFF
--- a/lua/hbac/command/actions.lua
+++ b/lua/hbac/command/actions.lua
@@ -19,11 +19,11 @@ M.toggle_pin = function(bufnr)
 	return bufnr, pinned_state
 end
 
-M.set_all = function(pin_value)
+M.set_all = function(pinned)
 	local utils = require("hbac.utils")
 	local buflist = utils.get_listed_buffers()
 	for _, bufnr in ipairs(buflist) do
-		state.pinned_buffers[bufnr] = pin_value
+		state.set_pin(bufnr, pinned)
 	end
 end
 

--- a/lua/hbac/state.lua
+++ b/lua/hbac/state.lua
@@ -1,15 +1,29 @@
 local M = {
-	pinned_buffers = {},
 	autoclose_enabled = false,
 }
 
-M.toggle_pin = function(bufnr)
-	M.pinned_buffers[bufnr] = not M.pinned_buffers[bufnr]
-	return M.pinned_buffers[bufnr]
+M.is_pinned = function(bufnr)
+	local utils = require("hbac.utils")
+	local pins = utils.get_pins()
+	return vim.tbl_contains(pins, bufnr)
 end
 
-M.is_pinned = function(bufnr)
-	return M.pinned_buffers[bufnr] == true
+M.set_pin = function(bufnr, pinned)
+	local utils = require("hbac.utils")
+	local pins = utils.get_pins()
+	if pinned and not M.is_pinned(bufnr) then
+		table.insert(pins, bufnr)
+		utils.set_pins(pins)
+	elseif not pinned and M.is_pinned(bufnr) then
+		local filtered_pins = vim.tbl_filter(function(pin) return pin ~= bufnr end, pins)
+		utils.set_pins(filtered_pins)
+	end
+end
+
+M.toggle_pin = function(bufnr)
+	local value = M.is_pinned(bufnr)
+	M.set_pin(bufnr, not value)
+	return not value
 end
 
 return M

--- a/lua/hbac/utils.lua
+++ b/lua/hbac/utils.lua
@@ -21,4 +21,21 @@ M.buf_autoclosable = function(bufnr)
 	return true
 end
 
+M.get_pins = function()
+	local pin_string = vim.g.Hbac_pinned_buffers or ""
+	if string.len(pin_string) == 0 then
+		return {}
+	end
+	local t = {}
+	for entry in string.gmatch(pin_string, "[^,]+") do
+		table.insert(t, tonumber(entry))
+	end
+	return t
+end
+
+M.set_pins = function(pins)
+	vim.g.Hbac_pinned_buffers = table.concat(pins, ",")
+end
+
+
 return M


### PR DESCRIPTION
Continuation of #22 (shoutout to @Nimjii)

This PR fixes #15, adding support for `mksession` and session plugins. I've been able to test it with manual `mksession`/`source`, as well as `auto-sessions`.