### PR TITLE
Count pinned option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ with [lazy.nvim](https://github.com/folke/lazy.nvim)
 require("hbac").setup({
   autoclose     = true, -- set autoclose to false if you want to close manually
   threshold     = 10, -- hbac will start closing unedited buffers once that number is reached
+  count_pinned  = true, -- whether pinned buffers will count towards the autoclose threshold
   close_command = function(bufnr)
     vim.api.nvim_buf_delete(bufnr, {})
   end,

--- a/lua/hbac/autocommands.lua
+++ b/lua/hbac/autocommands.lua
@@ -38,10 +38,12 @@ local function check_buffers()
 	end
 
 	local buffers = vim.tbl_filter(function(buf)
-		-- Filter out buffers that are not listed
-		return vim.api.nvim_buf_get_option(buf, "buflisted")
+		-- Filter out buffers that are not listed.
+		return vim.api.nvim_buf_get_option(buf, "buflisted") and (config.values.count_pinned or !state.is_pinned(buf))
 	end, vim.api.nvim_list_bufs())
+
 	local num_buffers = #buffers
+
 	if num_buffers <= config.values.threshold then
 		return
 	end

--- a/lua/hbac/autocommands.lua
+++ b/lua/hbac/autocommands.lua
@@ -38,7 +38,7 @@ local function check_buffers()
 	end
 
 	local buffers = vim.tbl_filter(function(buf)
-		-- Filter out buffers that are not listed.
+		-- Filter out buffers that are not listed, and pinned buffers if count_pinned == false
 		return vim.api.nvim_buf_get_option(buf, "buflisted") and (config.values.count_pinned or not state.is_pinned(buf))
 	end, vim.api.nvim_list_bufs())
 

--- a/lua/hbac/autocommands.lua
+++ b/lua/hbac/autocommands.lua
@@ -39,7 +39,7 @@ local function check_buffers()
 
 	local buffers = vim.tbl_filter(function(buf)
 		-- Filter out buffers that are not listed.
-		return vim.api.nvim_buf_get_option(buf, "buflisted") and (config.values.count_pinned or !state.is_pinned(buf))
+		return vim.api.nvim_buf_get_option(buf, "buflisted") and (config.values.count_pinned or not state.is_pinned(buf))
 	end, vim.api.nvim_list_bufs())
 
 	local num_buffers = #buffers

--- a/lua/hbac/config.lua
+++ b/lua/hbac/config.lua
@@ -3,6 +3,7 @@ local M = {}
 local defaults = {
 	autoclose = true,
 	threshold = 10,
+	count_pinned = true,
 	close_buffers_with_windows = false,
 	close_command = function(bufnr) vim.api.nvim_buf_delete(bufnr, {}) end,
 	telescope = {


### PR DESCRIPTION
Adds the config option `count_pinned`, which determines whether pinned buffers count towards the autoclose threshold.

Closes #34 