### PR TITLE
Autopin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ with [lazy.nvim](https://github.com/folke/lazy.nvim)
 # configuration
 ```lua
 require("hbac").setup({
-  autoclose     = true, -- set autoclose to false if you want to close manually
-  threshold     = 10, -- hbac will start closing unedited buffers once that number is reached
-  count_pinned  = true, -- whether pinned buffers will count towards the autoclose threshold
-  close_command = function(bufnr)
+  autoclose      = true, -- set autoclose to false if you want to close buffers manually
+  autopin        = true, -- set autopin to false if you want to pin buffers manually
+  autopin_events = { "InsertEnter", "BufModifiedSet" }, -- The vim events on which autopin will trigger, given that it is enabled
+  threshold      = 10, -- hbac will start closing unedited buffers once that number is reached
+  count_pinned   = true, -- whether pinned buffers will count towards the autoclose threshold
+  close_command  = function(bufnr)
     vim.api.nvim_buf_delete(bufnr, {})
   end,
   close_buffers_with_windows = false, -- hbac will close buffers with associated windows if this option is `true`
@@ -48,6 +50,7 @@ or
 - `:Hbac pin_all` - pin all buffers
 - `:Hbac unpin_all` - unpin all buffers
 - `:Hbac toggle_autoclose` - toggle autoclose behavior
+- `:Hbac toggle_autopin` - toggle autopin behaviour
 - `:Hbac telescope` - open the telescope picker
 
 or, if you prefer to use lua:
@@ -59,6 +62,7 @@ hbac.close_unpinned()
 hbac.pin_all()
 hbac.unpin_all()
 hbac.toggle_autoclose()
+hbac.toggle_autopin()
 ```
 
 ## Telescope extension

--- a/lua/hbac/autocommands.lua
+++ b/lua/hbac/autocommands.lua
@@ -104,6 +104,7 @@ M.autoclose.disable = function()
 end
 
 M.autopin.setup = function()
+	state.autopin_enabled = true
 	local id = vim.api.nvim_create_augroup(M.autopin.name, {
 		clear = false,
 	})
@@ -124,6 +125,14 @@ M.autopin.setup = function()
 			})
 		end,
 	})
+end
+
+M.autopin.disable = function()
+	-- pcall failure likely indicates that augroup doesn't exist - which is fine, since its
+	-- autocmds is effectively disabled in that case
+	pcall(function()
+		vim.api.nvim_del_augroup_by_name(M.autopin.name)
+	end)
 end
 
 return M

--- a/lua/hbac/autocommands.lua
+++ b/lua/hbac/autocommands.lua
@@ -111,7 +111,7 @@ M.autopin.setup = function()
 		group = id,
 		pattern = { "*" },
 		callback = function()
-			vim.api.nvim_create_autocmd({ "InsertEnter", "BufModifiedSet" }, {
+			vim.api.nvim_create_autocmd(config.values.autopin_events, {
 				buffer = 0,
 				once = true,
 				callback = function()

--- a/lua/hbac/autocommands.lua
+++ b/lua/hbac/autocommands.lua
@@ -104,6 +104,9 @@ M.autoclose.disable = function()
 end
 
 M.autopin.setup = function()
+	if #config.values.autopin_events == 0 then
+		return
+	end
 	state.autopin_enabled = true
 	local id = vim.api.nvim_create_augroup(M.autopin.name, {
 		clear = false,

--- a/lua/hbac/command/actions.lua
+++ b/lua/hbac/command/actions.lua
@@ -49,4 +49,15 @@ M.toggle_autoclose = function()
 	return state.autoclose_enabled
 end
 
+M.toggle_autopin = function()
+	local autocommands = require("hbac.autocommands")
+	state.autopin_enabled = not state.autopin_enabled
+	if state.autopin_enabled then
+		autocommands.autopin.setup()
+		return state.autopin_enabled
+	end
+	autocommands.autopin.disable()
+	return state.autopin_enabled
+end
+
 return M

--- a/lua/hbac/command/subcommands.lua
+++ b/lua/hbac/command/subcommands.lua
@@ -1,5 +1,6 @@
 local actions = require("hbac.command.actions")
 local notify_opts = require("hbac.command.config").notify_opts
+local config = require("hbac.config")
 
 local M = {}
 
@@ -29,8 +30,12 @@ M.toggle_autoclose = function()
 end
 
 M.toggle_autopin = function()
-	local autopin_state = actions.toggle_autopin() and "enabled" or "disabled"
-	vim.notify("Autopin " .. autopin_state, vim.log.levels.INFO, notify_opts)
+	local autopin_enabled = actions.toggle_autopin()
+	if autopin_enabled then
+		vim.notify("Autopin enabled on events { " .. table.concat(config.values.autopin_events, ",") .. " }", vim.log.levels.INFO, notify_opts)
+	else
+		vim.notify("Autopin disabled", vim.log.levels.INFO, notify_opts)
+	end
 end
 
 M.telescope = function()

--- a/lua/hbac/command/subcommands.lua
+++ b/lua/hbac/command/subcommands.lua
@@ -28,6 +28,11 @@ M.toggle_autoclose = function()
 	vim.notify("Autoclose " .. autoclose_state, vim.log.levels.INFO, notify_opts)
 end
 
+M.toggle_autopin = function()
+	local autopin_state = actions.toggle_autopin() and "enabled" or "disabled"
+	vim.notify("Autopin " .. autopin_state, vim.log.levels.INFO, notify_opts)
+end
+
 M.telescope = function()
 	vim.notify('This command has been removed. Check https://github.com/axkirillov/hbac.nvim?tab=readme-ov-file#telescope-extension for how to enable the telescope extension', vim.log.levels.WARN, notify_opts)
 end

--- a/lua/hbac/command/subcommands.lua
+++ b/lua/hbac/command/subcommands.lua
@@ -1,6 +1,7 @@
 local actions = require("hbac.command.actions")
 local notify_opts = require("hbac.command.config").notify_opts
 local config = require("hbac.config")
+local state = require("hbac.state")
 
 local M = {}
 
@@ -30,7 +31,13 @@ M.toggle_autoclose = function()
 end
 
 M.toggle_autopin = function()
+	if (not state.autopin_enabled) and #config.values.autopin_events == 0 then
+		vim.notify("Cannot enable autopin. No autopin events are configured.", vim.log.levels.WARN, notify_opts)
+		return
+	end
+
 	local autopin_enabled = actions.toggle_autopin()
+
 	if autopin_enabled then
 		vim.notify("Autopin enabled on events { " .. table.concat(config.values.autopin_events, ",") .. " }", vim.log.levels.INFO, notify_opts)
 	else

--- a/lua/hbac/config.lua
+++ b/lua/hbac/config.lua
@@ -2,6 +2,8 @@ local M = {}
 
 local defaults = {
 	autoclose = true,
+	autopin = true,
+	autopin_events = { "InsertEnter", "BufModifiedSet" },
 	threshold = 10,
 	count_pinned = true,
 	close_buffers_with_windows = false,

--- a/lua/hbac/init.lua
+++ b/lua/hbac/init.lua
@@ -9,5 +9,6 @@ return {
 	pin_all = command.subcommands.pin_all,
 	unpin_all = command.subcommands.unpin_all,
 	toggle_autoclose = command.subcommands.toggle_autoclose,
+	toggle_autopin = command.subcommands.toggle_autopin,
 	toggle_pin = command.subcommands.toggle_pin,
 }

--- a/lua/hbac/setup.lua
+++ b/lua/hbac/setup.lua
@@ -12,8 +12,6 @@ M.setup = function(user_opts)
 		autocommands.autopin.setup()
 	end
 
-	autocommands.autopin.setup()
-
 	command.create_user_command()
 
 	if config.values.autoclose then

--- a/lua/hbac/setup.lua
+++ b/lua/hbac/setup.lua
@@ -8,6 +8,10 @@ local M = {
 M.setup = function(user_opts)
 	config.setup(user_opts)
 
+	if config.values.autopin then
+		autocommands.autopin.setup()
+	end
+
 	autocommands.autopin.setup()
 
 	command.create_user_command()

--- a/lua/hbac/state.lua
+++ b/lua/hbac/state.lua
@@ -1,5 +1,6 @@
 local M = {
 	autoclose_enabled = false,
+	autopin_enabled = false,
 }
 
 M.is_pinned = function(bufnr)


### PR DESCRIPTION
- Added options to config `autopin` (bool) which determines whether autopin behaviour is active, and `autopin_events` (array), which determines which Vim events on which autopin triggers, given that it is enabled.
- Added a `toggle_autopin` action that does exactly what you think. Entirely analogous to the `toggle_autoclose` action.

Closes #36 